### PR TITLE
feat: Use img bytes instead of url

### DIFF
--- a/zitch-backend/api/classifier.go
+++ b/zitch-backend/api/classifier.go
@@ -7,7 +7,7 @@ import (
 
 func (app *application) callClassifierHandler(w http.ResponseWriter, r *http.Request) {
 	var input struct {
-		Imgurl string `json:"imgurl"`
+		Imgurl []byte `json:"img"`
 	}
 
 	err := app.readJSON(w, r, &input)

--- a/zitch-backend/api/inference/inference.go
+++ b/zitch-backend/api/inference/inference.go
@@ -43,7 +43,6 @@ package inference
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"google.golang.org/grpc"
 )
@@ -52,13 +51,13 @@ const (
 	address = "localhost:50051"
 )
 
-func Inference(imagePath string) (int32, int32, error) {
+func Inference(imageData []byte) (int32, int32, error) {
 	// Read image data
-	imageData, err := os.ReadFile(imagePath)
+	// imageData, err := os.ReadFile(imagePath)
 
-	if err != nil {
-		return -1, -1, fmt.Errorf("error reading image: %v", err)
-	}
+	// if err != nil {
+	// 	return -1, -1, fmt.Errorf("error reading image: %v", err)
+	// }
 	// Connect to the server
 	conn, err := grpc.Dial(address, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {


### PR DESCRIPTION
Only 2 changes made. Route now takes in a stream of bytes and is directly passed to inference function. Inference function instead of reading a file from system, directly uses the data given and sends to classifier. 